### PR TITLE
Update mobile.scss

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -15,7 +15,7 @@
         }
     }
 	.badge-notification {
-        font-size: .85em;
+        font-size: var(--font-down-2);
     }
     .topic-item-stats {
 		pointer-events: auto !important;


### PR DESCRIPTION
The new message badge is too large, I suggest using the default size instead.
![image](https://user-images.githubusercontent.com/5654300/170476405-9cd3724e-e558-4af7-89cd-96cbf3fa222c.png) 
![image](https://user-images.githubusercontent.com/5654300/170476460-fd0e39f8-a652-4434-9e33-c4e2f1d5e7a5.png)

